### PR TITLE
Update export.lib.php #issue 11827 

### DIFF
--- a/libraries/export.lib.php
+++ b/libraries/export.lib.php
@@ -190,15 +190,7 @@ function PMA_getHtmlForDisplayedExportFooter($back_button)
         . '    </form>'
         // bottom back button
         . $back_button
-        . '</div>'
-        . '<script type="text/javascript">' . "\n"
-        . '//<![CDATA[' . "\n"
-        . 'var $body = $("body");' . "\n"
-        . '$("#textSQLDUMP")' . "\n"
-        . '.width($body.width() - 50)' . "\n"
-        . '.height($body.height() - 100);' . "\n"
-        . '//]]>' . "\n"
-        . '</script>' . "\n";
+        . '</div>';
     return $html;
 }
 


### PR DESCRIPTION
Export: when viewing as text, the text area is collapsed #11827 solved.
Removed Local Javascript which was creating an issue.
The textarea is already styled in common.css.php